### PR TITLE
add scroll event when extending the tiles

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,6 +190,10 @@ const extendRows = () => {
         tileContainer.append(rowElement)
         guessRows.push(newRow)
     })
+    tileContainer.scroll({
+        top: tileContainer.scrollTop += 350,
+        behavior: "smooth"
+    })
 }
 
 const flipTile = () => {


### PR DESCRIPTION
When a user reaches the final tile in a set of tiles and still provides a wrong answer, the tile container scrolls down to allow for more input.